### PR TITLE
chore: update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,11 @@ inputs:
       Example: {'js': ['//', '/*'], 'py': ['#']}"
     required: false
     default: '{}'
+  custom_ignore_matcher:
+    description: "Add custom regex to ignore TODOs that match in the same 
+      line.\
+      Example: my-issue-website.com"
+    required: false
 
 runs:
   using: 'node20'

--- a/action.yml
+++ b/action.yml
@@ -38,8 +38,7 @@ inputs:
     required: false
     default: '{}'
   custom_ignore_matcher:
-    description: "Add custom regex to ignore TODOs that match in the same 
-      line.\
+    description: "Add custom regex to ignore TODOs that match in the same line.\
       Example: my-issue-website.com"
     required: false
 


### PR DESCRIPTION
The action correctly validates picks up custom_ignore_matcher, but still warns because it is not present in the action.yml input
